### PR TITLE
add needed sudo and correct mismatched file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ sudo apt-get update
 sudo apt-get install -y ca-certificates curl
 
 sudo install -m 0755 -d /usr/share/keyrings
-curl -fsSL https://mrchicken.nexussfan.cz/publickey.asc | gpg --dearmor | tee /usr/share/keyrings/NexusSfan.pgp > /dev/null
-sudo chmod a+r /usr/share/keyrings/NexusSfan.asc
+curl -fsSL https://mrchicken.nexussfan.cz/publickey.asc | gpg --dearmor | sudo tee /usr/share/keyrings/NexusSfan.pgp > /dev/null
+sudo chmod a+r /usr/share/keyrings/NexusSfan.pgp
 
 cat <<EOF | sudo tee /etc/apt/sources.list.d/xlibre-debian.sources
 Types: deb


### PR DESCRIPTION
running tee without sudo gives an access denied error, and chmod fails due to being unable to find NexusSfan.asc since .pgp is used